### PR TITLE
Update Program.cs

### DIFF
--- a/Ziggs/Program.cs
+++ b/Ziggs/Program.cs
@@ -161,7 +161,7 @@ namespace Ziggs
 
         private static void AntiGapcloser_OnEnemyGapcloser(ActiveGapcloser gapcloser)
         {
-            W.Cast(gapcloser.Sender);
+            W.Cast(gapcloser.End);
         }
 
         private static void Drawing_OnDraw(EventArgs args)


### PR DESCRIPTION
gapcloser.End will 100% make gapcloser get away, meanwhile gapcloser.Sender can miss(second Lee Q for example)
